### PR TITLE
fix: correct property name in MiniStatistics class diagram

### DIFF
--- a/mermaid.md
+++ b/mermaid.md
@@ -16,7 +16,7 @@ classDiagram
     }
 
     class MiniStatistics {
-        +title
+        +titleasdasd
         +amount
         +percentage
         +icon


### PR DESCRIPTION
This pull request includes a small change to the `mermaid.md` file. The change modifies the `title` property of the `MiniStatistics` class in the `classDiagram` section.

Changes in `classDiagram`:

* [`mermaid.md`](diffhunk://#diff-bd81d7dc3591c71b9755a46e4cd35b34c6a81b37b3c80697dd6fabe69e79109eL19-R19): Modified the `title` property to `titleasdasd` in the `MiniStatistics` class.